### PR TITLE
Bug/challenge/#57

### DIFF
--- a/src/api/challenge.ts
+++ b/src/api/challenge.ts
@@ -10,8 +10,8 @@ router.get("/", auth, async (req, res) => {
   res.json(result);
 });
 
-router.get("/:courseId/:challengeId", auth, async (req, res) => {
-  const result = await challengeService.today(req.body.user.id, req.params.courseId, req.params.challengeId);
+router.get("/:courseId", auth, async (req, res) => {
+  const result = await challengeService.today(req.body.user.id, req.params.courseId);
 
   res.json(result);
 });

--- a/src/controller/dateController.ts
+++ b/src/controller/dateController.ts
@@ -1,0 +1,10 @@
+export const isSameDay = (date1: Date, date2: Date) => {
+  return date1.getFullYear() === date2.getFullYear()
+        && date1.getMonth() === date2.getMonth()
+        && date1.getDate() === date2.getDate();
+}
+
+export const isSameMonth = (date1: Date, date2: Date) => {
+  return date1.getFullYear() === date2.getFullYear()
+        && date1.getMonth() === date2.getMonth();
+}

--- a/src/interfaces/IUser.ts
+++ b/src/interfaces/IUser.ts
@@ -1,5 +1,6 @@
 import { IMessage } from "./IMessage";
 import { IUserCourse } from "./IUserCourse"
+import { IUserSuccessChallenge } from "./IUserSurccessChallenge";
 
 export interface IUser {
 	id?: string; // fcm token
@@ -10,6 +11,7 @@ export interface IUser {
 	birthYear: number;
 	situation: number;	// default 0
 	affinity: number; // default 0
+	success: IUserSuccessChallenge;
 	messages?: IMessage[];
 	courses?: IUserCourse[];
 }

--- a/src/interfaces/IUserSurccessChallenge.ts
+++ b/src/interfaces/IUserSurccessChallenge.ts
@@ -1,0 +1,5 @@
+export interface IUserSuccessChallenge {
+  maxCount: number;
+  currentCount: number;
+  recentDate?: Date;
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -37,6 +37,19 @@ const UserSchema = new mongoose.Schema({
     type: Number,
     default: 20,
   },
+  success: {
+    maxCount: {
+      type: Number,
+      default: 0,
+    },
+    currentCount: {
+      type: Number,
+      default: 0,
+    },
+    recentDate: {
+      type: Date,
+    },
+  },
   messages: [
     {
       jouneyMessages: [

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -45,23 +45,13 @@ export default {
         };
         return notProgressCourse;
       }
-      // user.courses.forEach((course) => {
-      //   if (course.situation === 0) {
-      //     if (course.id === progressCourseId) {
-      //       const notProgressCourse: IFail = {
-      //         status: 400,
-      //         message: "현재 진행 중인 코스가 아닙니다.",
-      //       };
-      //       return notProgressCourse;
-      //     }
-      //   }
-      // });
-      
+
       let userCourse = user.courses[progressCourseId - 1];
       // 해당 challenge id가 진행 중이 아닐 경우
       if (
         user.courses.find((course) => course.id === progressCourseId)
-            .challenges.find((challenge) => challenge.situation === 0)
+            .challenges.filter((challenge) => (challenge.situation === 0) && (challenge.id === progressChallengeId))
+            .length > 0
       ) {
         const notProgressChallenge: IFail = {
           status: 400,
@@ -69,13 +59,6 @@ export default {
         };
         return notProgressChallenge;
       }
-      // if (userCourse.challenges[progressChallengeId - 1].situation === 0) {
-      //   const notProgressChallenge: IFail = {
-      //     status: 400,
-      //     message: "현재 진행 중인 챌린지가 아닙니다.",
-      //   };
-      //   return notProgressChallenge;
-      // }
 
       // date가 null
       if (
@@ -87,9 +70,6 @@ export default {
             .challenges.find((challenge) => challenge.id === progressChallengeId)
             .date = today;
       }
-      // if (userCourse.challenges[progressChallengeId - 1].date == null) {
-      //   user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
-      // }
 
       // 완료한 챌린지
       const challenge = user.courses.find((course) => course.id === progressCourseId)
@@ -104,17 +84,6 @@ export default {
             .challenges.find((challenge) => challenge.id === progressChallengeId)
             .date = today;
       }
-      // if ((userCourse.challenges[progressChallengeId - 1].date != today) 
-      //   && (userCourse.challenges[progressChallengeId - 1].situation === 2) 
-      //   && (progressCourseId + 1 <= courses.length))
-      // {
-      //   // 해당 코스의 마지막 챌린지
-      //   if (progressChallengeId != userCourse.challenges.length) {
-      //     progressChallengeId = progressChallengeId + 1;
-      //     user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].situation = 1;
-      //     user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
-      //   }
-      // }
 
       // 진행 중인 챌린지 리셋
       if ((challenge.date != today) && (challenge.situation === 1)) {
@@ -125,10 +94,6 @@ export default {
             .challenges.find((challenge) => challenge.id === progressChallengeId)
             .date = today;
       }
-      // if ((userCourse.challenges[progressChallengeId - 1].date != today) && (userCourse.challenges[progressChallengeId - 1].situation === 1)) {
-      //   user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].currentStamp = 0;
-      //   user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
-      // }
 
       await user.save();
 
@@ -141,25 +106,29 @@ export default {
       let challengeArray: Array<TodayChallengeDetailResponseDTO> = new Array<TodayChallengeDetailResponseDTO>();
       userCourse.challenges.forEach((challenge) => {
         let ments: Array<String> = new Array<String>();
-        dummyChallenge[challenge.id - 1].userMents.forEach((ment) => {
-          ments.push(ment.ment);
+        const currentChallenge = courses.find((course) => course.id === progressCourseId)
+                                        .challenges.find((challenge) => challenge.id === progressChallengeId);
+        currentChallenge
+          .userMents.forEach((ment) => {
+            ments.push(ment.ment);
         });
 
         const responseChallenge: TodayChallengeDetailResponseDTO = {
           id: challenge.id,
           situation: challenge.situation,
-          title: dummyChallenge[challenge.id - 1].title,
-          description: dummyChallenge[challenge.id - 1].description,
+          title: currentChallenge.title,
+          description: currentChallenge.description,
           year: challenge.year,
           month: challenge.month,
           day: challenge.day,
           currentStamp: challenge.currentStamp,
-          totalStamp: dummyChallenge[challenge.id - 1].totalStamp,
+          totalStamp: currentChallenge.totalStamp,
           userMents: ments
         };
         challengeArray.push(responseChallenge);
       });
 
+      
       // 최종 responseDTO
       const responseDTO: TodayChallengeResponseDTO = {
         status: 200,

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -35,57 +35,107 @@ export default {
       } 
       
       // 진행 중인 코스가 아닐 경우
-      user.courses.forEach((course) => {
-        if (course.situation === 0) {
-          if (course.id === progressCourseId) {
-            const notProgressCourse: IFail = {
-              status: 400,
-              message: "현재 진행 중인 코스가 아닙니다.",
-            };
-            return notProgressCourse;
-          }
-        }
-      });
+      if (
+        user.courses.filter((course) => (course.situation === 0) && (course.id === progressCourseId))
+            .length > 0
+      ) {
+        const notProgressCourse: IFail = {
+          status: 400,
+          message: "현재 진행 중인 코스가 아닙니다.",
+        };
+        return notProgressCourse;
+      }
+      // user.courses.forEach((course) => {
+      //   if (course.situation === 0) {
+      //     if (course.id === progressCourseId) {
+      //       const notProgressCourse: IFail = {
+      //         status: 400,
+      //         message: "현재 진행 중인 코스가 아닙니다.",
+      //       };
+      //       return notProgressCourse;
+      //     }
+      //   }
+      // });
       
       let userCourse = user.courses[progressCourseId - 1];
       // 해당 challenge id가 진행 중이 아닐 경우
-      if (userCourse.challenges[progressChallengeId - 1].situation === 0) {
+      if (
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.situation === 0)
+      ) {
         const notProgressChallenge: IFail = {
           status: 400,
           message: "현재 진행 중인 챌린지가 아닙니다.",
         };
         return notProgressChallenge;
       }
+      // if (userCourse.challenges[progressChallengeId - 1].situation === 0) {
+      //   const notProgressChallenge: IFail = {
+      //     status: 400,
+      //     message: "현재 진행 중인 챌린지가 아닙니다.",
+      //   };
+      //   return notProgressChallenge;
+      // }
 
       // date가 null
-      if (userCourse.challenges[progressChallengeId - 1].date == null) {
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
+      if (
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId)
+            .date === null
+      ) {
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId)
+            .date = today;
       }
+      // if (userCourse.challenges[progressChallengeId - 1].date == null) {
+      //   user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
+      // }
 
       // 완료한 챌린지
-      if ((userCourse.challenges[progressChallengeId - 1].date != today) 
-        && (userCourse.challenges[progressChallengeId - 1].situation === 2) 
-        && (progressCourseId + 1 <= courses.length))
-      {
-        // 해당 코스의 마지막 챌린지
-        if (progressChallengeId != userCourse.challenges.length) {
-          progressChallengeId = progressChallengeId + 1;
-          user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].situation = 1;
-          user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
-        }
+      const challenge = user.courses.find((course) => course.id === progressCourseId)
+                            .challenges.find((challenge) => challenge.id === progressChallengeId);
+      // 해당 코스의 마지막 챌린지
+      if ((challenge.date != today) && (challenge.situation === 2) && (progressCourseId + 1 <= courses.length)) {
+        progressChallengeId = progressChallengeId + 1;
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId)
+            .situation = 1;
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId)
+            .date = today;
       }
+      // if ((userCourse.challenges[progressChallengeId - 1].date != today) 
+      //   && (userCourse.challenges[progressChallengeId - 1].situation === 2) 
+      //   && (progressCourseId + 1 <= courses.length))
+      // {
+      //   // 해당 코스의 마지막 챌린지
+      //   if (progressChallengeId != userCourse.challenges.length) {
+      //     progressChallengeId = progressChallengeId + 1;
+      //     user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].situation = 1;
+      //     user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
+      //   }
+      // }
 
       // 진행 중인 챌린지 리셋
-      if ((userCourse.challenges[progressChallengeId - 1].date != today) && (userCourse.challenges[progressChallengeId - 1].situation === 1)) {
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].currentStamp = 0;
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
+      if ((challenge.date != today) && (challenge.situation === 1)) {
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId)
+            .currentStamp = 0;
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId)
+            .date = today;
       }
+      // if ((userCourse.challenges[progressChallengeId - 1].date != today) && (userCourse.challenges[progressChallengeId - 1].situation === 1)) {
+      //   user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].currentStamp = 0;
+      //   user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].date = today;
+      // }
 
       await user.save();
 
       // dummy data
-      dummyCourse = courses[progressCourseId - 1];
-      const dummyChallenge = courses[progressCourseId - 1].challenges;
+      dummyCourse = courses.find((course) => course.id === progressCourseId);
+      const dummyChallenge = courses.find((course) => course.id === progressCourseId)
+                                    .challenges.find((challenge) => challenge.id === progressChallengeId);
 
       // response할 challenge 배열 만들어서 저장
       let challengeArray: Array<TodayChallengeDetailResponseDTO> = new Array<TodayChallengeDetailResponseDTO>();

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -179,17 +179,32 @@ export default {
       }
 
       // 진행 중인 코스가 아닐 경우
-      user.courses.forEach((course) => {
-        if (course.situation != 1) {
-          if (course.id === progressCourseId) {
-            const notProgressCourse: IFail = {
-              status: 400,
-              message: "현재 진행 중인 코스가 아닙니다.",
-            }
-            return notProgressCourse;
-          }
-        }
-      });
+      if (
+        user.courses.filter((course) => (course.situation === 0) && (course.id === progressCourseId))
+            .length > 0
+      ) {
+        const notProgressCourse: IFail = {
+          status: 400,
+          message: "현재 진행 중인 코스가 아닙니다.",
+        };
+        return notProgressCourse;
+      }
+      console.log(user.courses.filter((course) => (course.situation === 0) && (course.id === progressCourseId)));
+
+      // 해당 challenge id가 진행 중이 아닐 경우
+      if (
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.filter((challenge) => (challenge.situation === 0) && (challenge.id === progressChallengeId))
+            .length > 0
+      ) {
+        const notProgressChallenge: IFail = {
+          status: 400,
+          message: "현재 진행 중인 챌린지가 아닙니다.",
+        };
+        return notProgressChallenge;
+      }
+      console.log(user.courses.find((course) => course.id === progressCourseId)
+      .challenges.filter((challenge) => (challenge.situation === 0) && (challenge.id === progressChallengeId)));
 
       const userCourse = user.courses[progressCourseId - 1];
       // 챌린지가 존재하지 않을 경우
@@ -201,40 +216,36 @@ export default {
         return notExistChallenge;
       }
 
-      // 해당 challenge id가 진행 중이 아닐 경우
-      if (userCourse.challenges[progressChallengeId - 1].situation != 1) {
-        const notProgressChallenge: IFail = {
-          status: 400,
-          message: "현재 진행 중인 챌린지가 아닙니다.",
-        };
-        return notProgressChallenge;
-      }
-
       // dummy data
       dummyCourse = courses[progressCourseId - 1];
       const dummyChallenge = courses[progressCourseId - 1].challenges;
       
       // stamp
-      const currentStamp = userCourse.challenges[progressChallengeId - 1].currentStamp;
-      const totalStamp = dummyChallenge[progressChallengeId - 1].totalStamp;
+      const currentStamp = user.courses.find((course) => course.id === progressCourseId)
+                              .challenges.find((challenge) => challenge.id === progressChallengeId).currentStamp;
+      const totalStamp = courses.find((course) => course.id === progressCourseId)
+                                .challenges.find((challenge) => challenge.id === progressChallengeId).totalStamp;
 
       // stamp 인증 처리
-      user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].currentStamp = currentStamp + 1;
+      user.courses.find((course) => course.id === progressCourseId)
+          .challenges.find((challenge) => challenge.id === progressChallengeId).currentStamp = currentStamp + 1;
 
+      // 인증 완료
       if (currentStamp + 1 === totalStamp) {
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].currentStamp = currentStamp + 1;
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].situation = 2;
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId).situation = 2;
         user.affinity = user.affinity + 2;
 
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].year = getYear();
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].month = getMonth();
-        user.courses[progressCourseId - 1].challenges[progressChallengeId - 1].day = getDay();
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId).year = getYear();
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId).month = getMonth();
+        user.courses.find((course) => course.id === progressCourseId)
+            .challenges.find((challenge) => challenge.id === progressChallengeId).day = getDay();
 
         // 현재 코스의 마지막 챌린지일 때 코스 situation을 진행 완료로 변경
         if (userCourse.challenges.length === progressChallengeId) {
-          user.courses[progressCourseId - 1].situation = 2;
-        } else {
-          user.courses[progressCourseId - 1].challenges[progressChallengeId].situation = 1;
+          user.courses.find((course) => course.id === progressCourseId).situation = 2;
         }
 
         // 최근 챌린지 성공 날짜가 어제라면, 연속 count + 1
@@ -257,20 +268,23 @@ export default {
       let challengeArray: Array<StampChallengeDetailResponseDTO> = new Array<StampChallengeDetailResponseDTO>();
       userCourse.challenges.forEach((challenge) => {
         let ments: Array<String> = new Array<String>();
-        dummyChallenge[challenge.id - 1].userMents.forEach((ment) => {
-          ments.push(ment.ment);
+        const currentChallenge = courses.find((course) => course.id === progressCourseId)
+                                        .challenges.find((challenge) => challenge.id === progressChallengeId);
+        currentChallenge
+          .userMents.forEach((ment) => {
+            ments.push(ment.ment);
         });
 
         const responseChallenge: TodayChallengeDetailResponseDTO = {
           id: challenge.id,
           situation: challenge.situation,
-          title: dummyChallenge[challenge.id - 1].title,
-          description: dummyChallenge[challenge.id - 1].description,
+          title: currentChallenge.title,
+          description: currentChallenge.description,
           year: challenge.year,
           month: challenge.month,
           day: challenge.day,
           currentStamp: challenge.currentStamp,
-          totalStamp: dummyChallenge[challenge.id - 1].totalStamp,
+          totalStamp: currentChallenge.totalStamp,
           userMents: ments
         };
         challengeArray.push(responseChallenge);
@@ -301,7 +315,6 @@ export default {
     try {
       const user = await User.findOne({ id: token });
       const courses = await Course.find();
-      let progressCourseId: number;
       
       // user jwt 토큰으로 유저 식별
       if (!user) {
@@ -313,11 +326,10 @@ export default {
       }
       
       // 진행 중인 코스 id 찾기
-      user.courses.forEach((course) => {
-        if (course.situation === 1) progressCourseId = course.id;
-      });
+      const progressCourseId = user.courses.find((course) => course.situation === 1).id;
+
       // 진행 중인 코스 id가 없는 경우
-      if (progressCourseId === null) {
+      if (!progressCourseId) {
         const notExistsCourseId: IFail = {
           status: 400,
           message: "진행 중인 코스가 없습니다.",
@@ -332,20 +344,23 @@ export default {
       let challengeArray: Array<ChallengeMapDetailResponseDTO> = new Array<ChallengeMapDetailResponseDTO>();
       userCourse.challenges.forEach((challenge) => {
         let ments: Array<String> = new Array<String>();
-        dummyChallenge[challenge.id - 1].userMents.forEach((ment) => {
-          ments.push(ment.ment);
+        const currentChallenge = courses.find((course) => course.id === progressCourseId)
+                                        .challenges.find((c) => c.id === challenge.id);
+        currentChallenge
+          .userMents.forEach((ment) => {
+            ments.push(ment.ment);
         });
 
         const responseChallenge: ChallengeMapDetailResponseDTO = {
           id: challenge.id,
           situation: challenge.situation,
-          title: dummyChallenge[challenge.id - 1].title,
-          description: dummyChallenge[challenge.id - 1].description,
+          title: currentChallenge.title,
+          description: currentChallenge.description,
           year: challenge.year,
           month: challenge.month,
           day: challenge.day,
           currentStamp: challenge.currentStamp,
-          totalStamp: dummyChallenge[challenge.id - 1].totalStamp,
+          totalStamp: currentChallenge.totalStamp,
           userMents: ments
         };
         challengeArray.push(responseChallenge);

--- a/src/service/challengeService.ts
+++ b/src/service/challengeService.ts
@@ -5,6 +5,7 @@ import TodayChallengeResponseDTO, { TodayChallengeDetailResponseDTO } from "../d
 import StampChallengeResponseDTO, { StampChallengeDetailResponseDTO } from "../dto/Challenge/StampChallenge/StampChallengeResponseDTO";
 import { getDay, getMonth, getYear } from "../formatter/challengeDateFormatter";
 import GetChallengeResponseDTO, { ChallengeMapDetailResponseDTO } from "../dto/Challenge/GetChallenge/GetChallengeResponseDTO";
+import { isSameDay } from "../controller/dateController";
 
 export default {
   today: async (token: String, courseId: String, challengeId: String) => {
@@ -75,7 +76,7 @@ export default {
       const challenge = user.courses.find((course) => course.id === progressCourseId)
                             .challenges.find((challenge) => challenge.id === progressChallengeId);
       // 해당 코스의 마지막 챌린지
-      if ((challenge.date != today) && (challenge.situation === 2) && (progressCourseId + 1 <= courses.length)) {
+      if ((isSameDay(today, challenge.date)) && (challenge.situation === 2) && (progressCourseId + 1 <= courses.length)) {
         progressChallengeId = progressChallengeId + 1;
         user.courses.find((course) => course.id === progressCourseId)
             .challenges.find((challenge) => challenge.id === progressChallengeId)
@@ -86,7 +87,7 @@ export default {
       }
 
       // 진행 중인 챌린지 리셋
-      if ((challenge.date != today) && (challenge.situation === 1)) {
+      if ((isSameDay(today, challenge.date)) && (challenge.situation === 1)) {
         user.courses.find((course) => course.id === progressCourseId)
             .challenges.find((challenge) => challenge.id === progressChallengeId)
             .currentStamp = 0;

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -111,7 +111,8 @@ export default {
           userChallenge.push({
             id: challenge.id,
             situation: 0,
-            currentStamp: 0
+            currentStamp: 0,
+            date: null
           });
         });
 

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -123,6 +123,7 @@ export default {
       user.situation = 1;
       user.courses[courseId - 1].situation = 1;
       user.courses[courseId - 1].challenges[0].situation = 1;
+      user.courses[courseId - 1].challenges[0].date = new Date();
 
       await user.save();
 

--- a/src/service/courseService.ts
+++ b/src/service/courseService.ts
@@ -120,6 +120,7 @@ export default {
         await user.save();
       }
 
+      user.situation = 1;
       user.courses[courseId - 1].situation = 1;
       user.courses[courseId - 1].challenges[0].situation = 1;
 


### PR DESCRIPTION
# [오늘의 챌린지 조회]
## 챌린지 완료 날짜가 오늘일 때
![image](https://user-images.githubusercontent.com/49138331/124976986-ebabeb80-e06a-11eb-8058-56de515ca367.png)

- 챌린지 완료 못했을 때 해당 챌린지 초기화
- 챌린지 완료 날짜가 오늘이 아닐 때 다음 챌린지 진행 상태로 변경

# [챌린지 인증하기]
- 챌린지 완료 시 쟈니와의 애정도 2% 증가
- 연속 인증 데이터 저장할 Success 인터페이스 User 모델에 추가
- 연속 인증 횟수, 현재 인증 횟수, 가장 최근 인증 등을 기록
- 마지막 챌린지 완료 시 user situation 0으로 변경

# [코스 진행하기]
- 코스 진행 시 user situation 1로 변경
- 코스 진행 시 date 저장
