### PR TITLE
bug: 소확행 작성 해시태그 에러처리 제거

### DIFF
--- a/src/api/smallSatisfaction.ts
+++ b/src/api/smallSatisfaction.ts
@@ -120,30 +120,6 @@ router.post("/write",
     mainImageUrl = "";
   }
 
-  let response;
-
-  if (req.body.hashtags) {
-    if ((req.body.hashtags).length>5) {
-      const hashtagsExceeded: IFail = {
-        status: 400,
-        message: "해시태그는 5개까지만 넣어주세요!",
-      };
-      response = hashtagsExceeded
-    }
-    
-    req.body.hashtags.forEach((hashtag) => { 
-      if (hashtag.length > 7) {
-        const hashtagExceeded: IFail = {
-          status: 400,
-          message: "해시태그는 6글자 이내로 작성해주세요!",
-        };
-        response = hashtagExceeded
-      }
-    });
-    if (response) {
-      return res.status(404).json(response);
-    }
-  }
   const requestDTO: SmallSatisfactionWriteRequestDTO = {
     content: req.body.content,
     mood: req.body.mood,


### PR DESCRIPTION
해시태그 하나만 보냈을 때 에러가 나서 고치려고 했는데 안돼서 일단은 에러처리를 삭제하는 쪽으로 가기로 했습니다...
클라에서 해시태그 개수랑 글자 제한 막아준다고 해서 서버는 삭제할게요 ... !

예를 들어서 #해시태그 이렇게 해시태그를 한개만 보냈을 때
["#", "해", "시", "태", "그"] 이런식으로 들어옵니다... 두 개이상 보낼 때는 잘 들어오는데
한 개만 들어오면 저렇게 돼서 에러 처리 아예 삭제합니다 .. !